### PR TITLE
Adds several tests, catches some errant references to "export" 

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -34,6 +34,7 @@ const path_1 = require("path");
 const prompt_sync_1 = __importDefault(require("prompt-sync"));
 const util_1 = __importDefault(require("util"));
 const BulkMatchClient_1 = __importDefault(require("./client/BulkMatchClient"));
+const default_config_1 = __importDefault(require("./default-config"));
 const lib_1 = require("./lib");
 const logger_1 = require("./logger");
 const reporters_1 = require("./reporters");
@@ -55,12 +56,11 @@ APP.option("-c, --count [number]", "The maximum number of records to return per 
 APP.option("-F, --_outputFormat [string]", `The output format you expect.`);
 APP.option("-d, --destination [destination]", "Download destination. See config/template-config.js for examples");
 APP.option("--reporter [cli|text]", 'Reporter to use to render the output. "cli" renders fancy progress bars and tables. "text" is better for log files. Defaults to "cli".');
-APP.option("--status [url]", "Status endpoint of already started export.");
+APP.option("--status [url]", "Status endpoint of already started match operation.");
 APP.action(async (args) => {
     const { config, ...params } = args;
     // Will be a js file after transpilation
-    const defaultsPath = (0, path_1.resolve)(__dirname, "./default-config.js");
-    const base = await Promise.resolve(`${defaultsPath}`).then(s => __importStar(require(s)));
+    const base = default_config_1.default;
     // Options will be a combination of Normalized Options and CLI Options, building up from the default config
     const options = {
         ...base,
@@ -114,10 +114,10 @@ APP.action(async (args) => {
         client.addLogger(logger);
     }
     process.on("SIGINT", () => {
-        console.log("\nExport canceled.".magenta.bold);
+        console.log("Match canceled.".magenta.bold);
         reporter.detach();
         client.abort();
-        // Should this cancel the export on the server?
+        // Should this cancel the match on the server?
         process.exit(0);
     });
     process.on("uncaughtException", (e) => {
@@ -143,7 +143,7 @@ APP.action(async (args) => {
     // - Create some sort of UI that makes it easier to define which responses in the
     //   match should move onto a final step where we do something like the steps above
     if (options.reporter === "cli") {
-        const answer = (0, prompt_sync_1.default)()("Do you want to signal the server that this export can be removed? [Y/n]".cyan);
+        const answer = (0, prompt_sync_1.default)()("Do you want to signal the server that this match can be removed? [Y/n]".cyan);
         if (!answer || answer.toLowerCase() === "y") {
             client
                 .cancelMatch(statusEndpoint)

--- a/build/client/BulkMatchClient.js
+++ b/build/client/BulkMatchClient.js
@@ -335,7 +335,6 @@ class BulkMatchClient extends SmartOnFhirClient_1.default {
                 message: msg,
                 responseHeaders: this._formatResponseHeaders(err.responseHeaders),
             });
-            throw new Error(msg);
         }
         // Else, just keep passing the error up
         throw err;
@@ -379,7 +378,7 @@ class BulkMatchClient extends SmartOnFhirClient_1.default {
             throw new Error(msg);
         })
             // This always throws, but allows for some middleware-style logging
-            .catch(this._statusError));
+            .catch((err) => this._statusError(err)));
     }
     /**
      * Makes the kick-off request for Patient Match and resolves with the status endpoint URL

--- a/build/lib/errors.js
+++ b/build/lib/errors.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.InvalidNdjsonError = exports.UnknownResourceStringError = exports.OperationOutcomeError = void 0;
+exports.RequestError = exports.InvalidNdjsonError = exports.UnknownResourceStringError = exports.OperationOutcomeError = void 0;
 const utils_1 = require("./utils");
 class OperationOutcomeError extends Error {
     constructor({ res }) {
@@ -40,3 +40,21 @@ class InvalidNdjsonError extends Error {
     }
 }
 exports.InvalidNdjsonError = InvalidNdjsonError;
+class RequestError extends Error {
+    constructor({ res, method }) {
+        const url = res.response.url;
+        const status = res.response.status;
+        const statusText = res.response.statusText;
+        const body = res.body;
+        super(`${method || "GET"} ${url} FAILED with ` +
+            `${status}` +
+            `${statusText ? ` and message ${statusText}` : ""}.` +
+            `${body ? " Body: " + JSON.stringify(body) : ""}`);
+        this.method = method;
+        this.url = url;
+        this.status = status;
+        this.statusText = statusText;
+        this.body = body;
+    }
+}
+exports.RequestError = RequestError;

--- a/build/lib/errors.js
+++ b/build/lib/errors.js
@@ -45,15 +45,17 @@ class RequestError extends Error {
         const url = res.response.url;
         const status = res.response.status;
         const statusText = res.response.statusText;
+        const responseHeaders = res.response.headers;
         const body = res.body;
         super(`${method || "GET"} ${url} FAILED with ` +
             `${status}` +
             `${statusText ? ` and message ${statusText}` : ""}.` +
-            `${body ? " Body: " + JSON.stringify(body) : ""}`);
+            `${body ? " Body: " + (0, utils_1.stringifyBody)(body) : ""}`);
         this.method = method;
         this.url = url;
         this.status = status;
         this.statusText = statusText;
+        this.responseHeaders = responseHeaders;
         this.body = body;
     }
 }

--- a/build/lib/request.js
+++ b/build/lib/request.js
@@ -27,10 +27,15 @@ async function augmentedFetch(input, options = {}) {
         if (body.length && contentType.match(/\bjson\b/i)) {
             body = JSON.parse(body);
         }
+        // Create eventual response now so we can use it in errror objects
+        const res = {
+            response,
+            body: body,
+        };
         // Throw errors for all non-200's, except 429
         if (!response.ok && response.status !== 429) {
             throw new errors_1.RequestError({
-                res: { response, body: body },
+                res,
                 method: options.method || "",
             });
         }
@@ -82,10 +87,7 @@ async function augmentedFetch(input, options = {}) {
                 }
             }
         }
-        return {
-            response,
-            body: body,
-        };
+        return res;
     })
         .catch((e) => {
         debug("FAILED fetch: ", e.message);

--- a/build/lib/request.js
+++ b/build/lib/request.js
@@ -28,7 +28,7 @@ async function augmentedFetch(input, options = {}) {
         }
         // Throw errors for all non-200's, except 429
         if (!response.ok && response.status !== 429) {
-            const message = `${options.method} ${input} FAILED with ` +
+            const message = `${options.method || "GET"} ${input} FAILED with ` +
                 `${response.status}` +
                 `${response.statusText ? ` and message ${response.statusText}` : ""}.` +
                 `${body ? " Body: " + JSON.stringify(body) : ""}`;

--- a/build/lib/request.js
+++ b/build/lib/request.js
@@ -8,6 +8,7 @@ require("colors");
 const prompt_sync_1 = __importDefault(require("prompt-sync"));
 const util_1 = __importDefault(require("util"));
 const package_json_1 = __importDefault(require("../../package.json"));
+const errors_1 = require("./errors");
 const utils_1 = require("./utils");
 const debug = util_1.default.debuglog("bulk-match-request");
 async function augmentedFetch(input, options = {}) {
@@ -28,11 +29,10 @@ async function augmentedFetch(input, options = {}) {
         }
         // Throw errors for all non-200's, except 429
         if (!response.ok && response.status !== 429) {
-            const message = `${options.method || "GET"} ${input} FAILED with ` +
-                `${response.status}` +
-                `${response.statusText ? ` and message ${response.statusText}` : ""}.` +
-                `${body ? " Body: " + JSON.stringify(body) : ""}`;
-            throw new Error(message);
+            throw new errors_1.RequestError({
+                res: { response, body: body },
+                method: options.method || "",
+            });
         }
         debug("\n=======================================================" +
             "\n--------------------- Request -------------------------" +

--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -299,6 +299,7 @@ function formatDuration(ms) {
         { n: 1000 * 60 * 60, label: "hour" },
         { n: 1000 * 60, label: "minute" },
         { n: 1000, label: "second" },
+        { n: 1, label: "millisecond" },
     ];
     meta.reduce((prev, cur) => {
         const chunk = Math.floor(prev / cur.n); // console.log(chunk)

--- a/build/lib/utils.js
+++ b/build/lib/utils.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.assert = exports.print = exports.formatDatetimeTimestamp = exports.formatDuration = exports.generateProgress = exports.humanFileSize = exports.wait = exports.parseBoolean = exports.fhirInstant = exports.displayCodeableConcept = exports.detectTokenUrl = exports.getTokenEndpointFromCapabilityStatement = exports.getTokenEndpointFromWellKnownSmartConfig = exports.getCapabilityStatement = exports.getWellKnownSmartConfig = exports.getAccessTokenExpiration = exports.filterResponseHeaders = void 0;
+exports.stringifyBody = exports.assert = exports.print = exports.formatDatetimeTimestamp = exports.formatDuration = exports.generateProgress = exports.humanFileSize = exports.wait = exports.parseBoolean = exports.fhirInstant = exports.displayCodeableConcept = exports.detectTokenUrl = exports.getTokenEndpointFromCapabilityStatement = exports.getTokenEndpointFromWellKnownSmartConfig = exports.getCapabilityStatement = exports.getWellKnownSmartConfig = exports.getAccessTokenExpiration = exports.filterResponseHeaders = void 0;
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 require("colors");
 const jsonwebtoken_1 = __importDefault(require("jsonwebtoken"));
@@ -369,3 +369,12 @@ function assert(condition, error, ctor = Error) {
     }
 }
 exports.assert = assert;
+/**
+ * Method for turning the either JSON or string content of a response body into a string
+ * @param body
+ * @returns
+ */
+function stringifyBody(body) {
+    return typeof body === "object" ? JSON.stringify(body) : body;
+}
+exports.stringifyBody = stringifyBody;

--- a/build/reporters/cli.js
+++ b/build/reporters/cli.js
@@ -44,14 +44,15 @@ class CLIReporter extends reporter_1.default {
         lib_1.Utils.print(`Begin ${itemType === "error" ? "error-file " : " "}download for ${fileUrl} at ${lib_1.Utils.formatDatetimeTimestamp(startTime)}...`).commit();
     }
     onDownloadComplete({ fileUrl, duration }) {
-        lib_1.Utils.print(`${fileUrl} download complete in ${lib_1.Utils.formatDuration(duration)}`).commit();
+        lib_1.Utils.print(`${fileUrl} download complete in ${duration}`).commit();
     }
-    onDownloadError({ fileUrl, message, duration, }) {
-        lib_1.Utils.print(`${fileUrl} download failed in ${lib_1.Utils.formatDuration(duration)}`).commit();
-        lib_1.Utils.print("Message: " + message).commit();
+    onDownloadError({ fileUrl, message, duration, responseHeaders, }) {
+        lib_1.Utils.print(`${fileUrl} download failed in ${duration}. Message: ${message}`).commit();
+        if (responseHeaders)
+            debug("responseHeaders: ", JSON.stringify(responseHeaders));
     }
     onAllDownloadsComplete(_, duration) {
-        lib_1.Utils.print(`All downloads completed in ${lib_1.Utils.formatDuration(duration)}`).commit();
+        lib_1.Utils.print(`All downloads completed in ${duration}`).commit();
     }
     onError(error) {
         console.error(error);

--- a/build/reporters/text.js
+++ b/build/reporters/text.js
@@ -40,16 +40,18 @@ class TextReporter extends reporter_1.default {
         console.error("There was an error in the matching process: ", JSON.stringify(details));
     }
     onDownloadStart({ fileUrl, itemType, startTime, }) {
-        console.log(`Begin ${itemType}-file download for ${fileUrl} at ${lib_1.Utils.formatDuration(startTime)}...`);
+        console.log(`Begin ${itemType}-file download for ${fileUrl} at ${lib_1.Utils.formatDatetimeTimestamp(startTime)}...`);
     }
     onDownloadComplete({ fileUrl, duration }) {
-        console.log(`${fileUrl} download completed in ${lib_1.Utils.formatDuration(duration)}`);
+        console.log(`${fileUrl} download completed in ${duration}`);
     }
-    onDownloadError({ fileUrl, message, duration, }) {
-        console.log(`${fileUrl} download FAILED in ${lib_1.Utils.formatDuration(duration)} Message: ${message}`);
+    onDownloadError({ fileUrl, message, duration, responseHeaders, }) {
+        console.log(`${fileUrl} download FAILED in ${duration} Message: ${message}`);
+        if (responseHeaders)
+            debug("Headers: ", JSON.stringify(responseHeaders));
     }
     onAllDownloadsComplete(_, duration) {
-        console.log(`All downloads completed in ${lib_1.Utils.formatDuration(duration)}`);
+        console.log(`All downloads completed in ${duration}`);
     }
     onError(error) {
         console.error(error);

--- a/build/reporters/text.js
+++ b/build/reporters/text.js
@@ -23,7 +23,7 @@ class TextReporter extends reporter_1.default {
     }
     onJobStart(status) {
         console.log(status.message);
-        console.log(`Status endpoint: ${status.statusEndpoint}`);
+        debug(`Status endpoint: ${status.statusEndpoint}`);
     }
     onJobProgress(status) {
         const { startedAt, elapsedTime, percentComplete, nextCheckAfter, message } = status;
@@ -37,8 +37,7 @@ class TextReporter extends reporter_1.default {
         debug(JSON.stringify(manifest));
     }
     onJobError(details) {
-        console.error("There was an error in the matching process");
-        console.error(JSON.stringify(details));
+        console.error("There was an error in the matching process: ", JSON.stringify(details));
     }
     onDownloadStart({ fileUrl, itemType, startTime, }) {
         console.log(`Begin ${itemType}-file download for ${fileUrl} at ${lib_1.Utils.formatDuration(startTime)}...`);
@@ -47,8 +46,7 @@ class TextReporter extends reporter_1.default {
         console.log(`${fileUrl} download completed in ${lib_1.Utils.formatDuration(duration)}`);
     }
     onDownloadError({ fileUrl, message, duration, }) {
-        console.log(`${fileUrl} download FAILED in ${lib_1.Utils.formatDuration(duration)}`);
-        console.log("Message: " + message);
+        console.log(`${fileUrl} download FAILED in ${lib_1.Utils.formatDuration(duration)} Message: ${message}`);
     }
     onAllDownloadsComplete(_, duration) {
         console.log(`All downloads completed in ${lib_1.Utils.formatDuration(duration)}`);

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,7 +127,7 @@ export declare namespace BulkMatchClient {
         reporter?: Reporter;
 
         /**
-         * Use if you have a status endpoint of an export that has already been
+         * Use if you have a status endpoint of a match that has already been
          * started.
          */
         status?: string;
@@ -489,7 +489,7 @@ export declare namespace BulkMatchClient {
          * including this instant.
          * Note: To properly meet these constraints, a FHIR Server might need
          * to wait for any pending transactions to resolve in its database
-         * before starting the export process.
+         * before starting the match process.
          */
         transactionTime: string; // FHIR instant
 
@@ -519,7 +519,7 @@ export declare namespace BulkMatchClient {
         /**
          * array of error file items following the same structure as the output
          * array.
-         * Errors that occurred during the export should only be included here
+         * Errors that occurred during the match should only be included here
          * (not in output). If no errors occurred, the server SHOULD return an
          * empty array. Only the OperationOutcome resource type is currently
          * supported, so a server SHALL generate files in the same format as
@@ -596,10 +596,10 @@ export declare namespace BulkMatchClient {
         /**
          * The value shows which part of the manifest this download comes from.
          * Can be:
-         * - "output"  - For exported files
+         * - "output"  - For matched files
          * - "error"   - For ndjson files with error operation outcomes
          */
-        readonly exportType: "output" | "error";
+        readonly matchType: "output" | "error";
     }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -56,7 +56,7 @@ APP.option(
     "--reporter [cli|text]",
     'Reporter to use to render the output. "cli" renders fancy progress bars and tables. "text" is better for log files. Defaults to "cli".',
 );
-APP.option("--status [url]", "Status endpoint of already started export.");
+APP.option("--status [url]", "Status endpoint of already started match operation.");
 
 APP.action(async (args: Types.CLIOptions) => {
     const { config, ...params } = args;
@@ -127,10 +127,10 @@ APP.action(async (args: Types.CLIOptions) => {
     }
 
     process.on("SIGINT", () => {
-        console.log("\nExport canceled.".magenta.bold);
+        console.log("Match canceled.".magenta.bold);
         reporter.detach();
         client.abort();
-        // Should this cancel the export on the server?
+        // Should this cancel the match on the server?
         process.exit(0);
     });
 
@@ -164,7 +164,7 @@ APP.action(async (args: Types.CLIOptions) => {
 
     if (options.reporter === "cli") {
         const answer = prompt()(
-            "Do you want to signal the server that this export can be removed? [Y/n]".cyan,
+            "Do you want to signal the server that this match can be removed? [Y/n]".cyan,
         );
         if (!answer || answer.toLowerCase() === "y") {
             client

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import prompt from "prompt-sync";
 import util from "util";
 import { BulkMatchClient as Types } from "..";
 import Client from "./client/BulkMatchClient";
+import defaultConfig from "./default-config";
 import { Utils } from "./lib";
 import { createLogger } from "./logger";
 import { CLIReporter, TextReporter } from "./reporters";
@@ -60,9 +61,8 @@ APP.option("--status [url]", "Status endpoint of already started export.");
 APP.action(async (args: Types.CLIOptions) => {
     const { config, ...params } = args;
     // Will be a js file after transpilation
-    const defaultsPath = resolve(__dirname, "./default-config.js");
 
-    const base: Types.NormalizedOptions = await import(defaultsPath);
+    const base: Types.ConfigFileOptions = defaultConfig;
     // Options will be a combination of Normalized Options and CLI Options, building up from the default config
     const options: Partial<Types.NormalizedOptions & Types.CLIOptions> = {
         ...base,

--- a/src/client/BulkMatchClient.ts
+++ b/src/client/BulkMatchClient.ts
@@ -365,7 +365,6 @@ class BulkMatchClient extends SmartOnFhirClient {
                 message: msg,
                 responseHeaders: this._formatResponseHeaders(err.responseHeaders),
             });
-            throw new Error(msg);
         }
         // Else, just keep passing the error up
         throw err;
@@ -422,7 +421,7 @@ class BulkMatchClient extends SmartOnFhirClient {
                     throw new Error(msg);
                 })
                 // This always throws, but allows for some middleware-style logging
-                .catch(this._statusError)
+                .catch((err) => this._statusError(err))
         );
     }
 

--- a/src/client/BulkMatchClientEvents.ts
+++ b/src/client/BulkMatchClientEvents.ts
@@ -63,7 +63,7 @@ export interface BulkMatchClientEvents extends SmartOnFhirClientEvents {
     ) => void;
 
     /**
-     * Emitted when the export is completed
+     * Emitted when the match is completed
      * @event
      */
     jobComplete: (this: BulkMatchClient, manifest: Types.MatchManifest) => void;

--- a/src/client/BulkMatchClientEvents.ts
+++ b/src/client/BulkMatchClientEvents.ts
@@ -90,7 +90,8 @@ export interface BulkMatchClientEvents extends SmartOnFhirClientEvents {
         details: {
             fileUrl: string;
             message?: string;
-            duration: number;
+            duration: string;
+            responseHeaders?: object;
         },
     ) => void;
 
@@ -102,7 +103,7 @@ export interface BulkMatchClientEvents extends SmartOnFhirClientEvents {
         this: BulkMatchClient,
         detail: {
             fileUrl: string;
-            duration: number;
+            duration: string;
         },
     ) => void;
 
@@ -113,7 +114,7 @@ export interface BulkMatchClientEvents extends SmartOnFhirClientEvents {
     allDownloadsComplete: (
         this: BulkMatchClient,
         downloads: (Types.FileDownload | PromiseRejectedResult)[],
-        duration: number,
+        duration: string,
     ) => void;
 
     // Extending types for SmartOnFhir Client Events

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -88,3 +88,37 @@ export class InvalidNdjsonError extends Error {
         Error.captureStackTrace(this, this.constructor);
     }
 }
+
+/**
+ * For managing non-200 responses at the request helper layer
+ */
+type RequestErrorArgs = {
+    res: Types.CustomBodyResponse<object>;
+    method: string;
+};
+
+export class RequestError<T> extends Error {
+    readonly method: string;
+    readonly url: string;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body?: T;
+
+    constructor({ res, method }: RequestErrorArgs) {
+        const url = res.response.url;
+        const status = res.response.status;
+        const statusText = res.response.statusText;
+        const body = res.body as T;
+        super(
+            `${method || "GET"} ${url} FAILED with ` +
+                `${status}` +
+                `${statusText ? ` and message ${statusText}` : ""}.` +
+                `${body ? " Body: " + JSON.stringify(body) : ""}`,
+        );
+        this.method = method;
+        this.url = url;
+        this.status = status;
+        this.statusText = statusText;
+        this.body = body;
+    }
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,5 @@
 import { BulkMatchClient as Types } from "../..";
-import { displayCodeableConcept } from "./utils";
+import { displayCodeableConcept, stringifyBody } from "./utils";
 
 /**
  * For throwing operationOutcome-related information as an error
@@ -92,8 +92,8 @@ export class InvalidNdjsonError extends Error {
 /**
  * For managing non-200 responses at the request helper layer
  */
-type RequestErrorArgs = {
-    res: Types.CustomBodyResponse<object>;
+type RequestErrorArgs<T> = {
+    res: Types.CustomBodyResponse<T>;
     method: string;
 };
 
@@ -102,23 +102,26 @@ export class RequestError<T> extends Error {
     readonly url: string;
     readonly status: number;
     readonly statusText: string;
+    readonly responseHeaders: Headers;
     readonly body?: T;
 
-    constructor({ res, method }: RequestErrorArgs) {
+    constructor({ res, method }: RequestErrorArgs<T>) {
         const url = res.response.url;
         const status = res.response.status;
         const statusText = res.response.statusText;
+        const responseHeaders = res.response.headers;
         const body = res.body as T;
         super(
             `${method || "GET"} ${url} FAILED with ` +
                 `${status}` +
                 `${statusText ? ` and message ${statusText}` : ""}.` +
-                `${body ? " Body: " + JSON.stringify(body) : ""}`,
+                `${body ? " Body: " + stringifyBody(body) : ""}`,
         );
         this.method = method;
         this.url = url;
         this.status = status;
         this.statusText = statusText;
+        this.responseHeaders = responseHeaders;
         this.body = body;
     }
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -33,7 +33,7 @@ async function augmentedFetch<T>(
                 // Throw errors for all non-200's, except 429
                 if (!response.ok && response.status !== 429) {
                     const message =
-                        `${options.method} ${input} FAILED with ` +
+                        `${options.method || "GET"} ${input} FAILED with ` +
                         `${response.status}` +
                         `${response.statusText ? ` and message ${response.statusText}` : ""}.` +
                         `${body ? " Body: " + JSON.stringify(body) : ""}`;

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -31,10 +31,16 @@ async function augmentedFetch<T>(
                     body = JSON.parse(body);
                 }
 
+                // Create eventual response now so we can use it in errror objects
+                const res = {
+                    response,
+                    body: body as T,
+                };
+
                 // Throw errors for all non-200's, except 429
                 if (!response.ok && response.status !== 429) {
                     throw new RequestError<T>({
-                        res: { response, body: body as T },
+                        res,
                         method: options.method || "",
                     });
                 }
@@ -98,10 +104,7 @@ async function augmentedFetch<T>(
                     }
                 }
 
-                return {
-                    response,
-                    body: body as T,
-                };
+                return res;
             })
             .catch((e: Error) => {
                 debug("FAILED fetch: ", e.message);

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -4,6 +4,7 @@ import prompt from "prompt-sync";
 import util from "util";
 import { BulkMatchClient as Types } from "../..";
 import pkg from "../../package.json";
+import { RequestError } from "./errors";
 import { print } from "./utils";
 
 const debug = util.debuglog("bulk-match-request");
@@ -32,12 +33,10 @@ async function augmentedFetch<T>(
 
                 // Throw errors for all non-200's, except 429
                 if (!response.ok && response.status !== 429) {
-                    const message =
-                        `${options.method || "GET"} ${input} FAILED with ` +
-                        `${response.status}` +
-                        `${response.statusText ? ` and message ${response.statusText}` : ""}.` +
-                        `${body ? " Body: " + JSON.stringify(body) : ""}`;
-                    throw new Error(message);
+                    throw new RequestError<T>({
+                        res: { response, body: body as T },
+                        method: options.method || "",
+                    });
                 }
                 debug(
                     "\n=======================================================" +

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -108,10 +108,10 @@ export async function getWellKnownSmartConfig(baseUrl: string): Promise<JsonObje
  */
 export async function getCapabilityStatement(baseUrl: string): Promise<fhir4.CapabilityStatement> {
     const url = new URL("metadata", baseUrl.replace(/\/*$/, "/"));
-    return request(url)
+    return request<fhir4.CapabilityStatement>(url)
         .then(async (res) => {
             debug("Fetched CapabilityStatement from %s", url);
-            return res.body as fhir4.CapabilityStatement;
+            return res.body;
         })
         .catch((e) => {
             debug(
@@ -319,6 +319,7 @@ export function formatDuration(ms: number) {
         { n: 1000 * 60 * 60, label: "hour" },
         { n: 1000 * 60, label: "minute" },
         { n: 1000, label: "second" },
+        { n: 1, label: "millisecond" },
     ];
 
     meta.reduce((prev, cur) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -400,3 +400,12 @@ export function assert(
         }
     }
 }
+
+/**
+ * Method for turning the either JSON or string content of a response body into a string
+ * @param body
+ * @returns
+ */
+export function stringifyBody(body: string | object | undefined) {
+    return typeof body === "object" ? JSON.stringify(body) : body;
+}

--- a/src/reporters/cli.ts
+++ b/src/reporters/cli.ts
@@ -68,24 +68,26 @@ export default class CLIReporter extends Reporter {
             `Begin ${itemType === "error" ? "error-file " : " "}download for ${fileUrl} at ${Utils.formatDatetimeTimestamp(startTime)}...`,
         ).commit();
     }
-    onDownloadComplete({ fileUrl, duration }: { fileUrl: string; duration: number }) {
-        Utils.print(`${fileUrl} download complete in ${Utils.formatDuration(duration)}`).commit();
+    onDownloadComplete({ fileUrl, duration }: { fileUrl: string; duration: string }) {
+        Utils.print(`${fileUrl} download complete in ${duration}`).commit();
     }
     onDownloadError({
         fileUrl,
         message,
         duration,
+        responseHeaders,
     }: {
         fileUrl: string;
         message: string;
-        duration: number;
+        duration: string;
+        responseHeaders?: object;
     }) {
-        Utils.print(`${fileUrl} download failed in ${Utils.formatDuration(duration)}`).commit();
-        Utils.print("Message: " + message).commit();
+        Utils.print(`${fileUrl} download failed in ${duration}. Message: ${message}`).commit();
+        if (responseHeaders) debug("responseHeaders: ", JSON.stringify(responseHeaders));
     }
 
-    onAllDownloadsComplete(_: unknown, duration: number) {
-        Utils.print(`All downloads completed in ${Utils.formatDuration(duration)}`).commit();
+    onAllDownloadsComplete(_: unknown, duration: string) {
+        Utils.print(`All downloads completed in ${duration}`).commit();
     }
 
     onError(error: Error) {

--- a/src/reporters/text.ts
+++ b/src/reporters/text.ts
@@ -61,30 +61,31 @@ export default class TextReporter extends Reporter {
         startTime: number;
     }) {
         console.log(
-            `Begin ${itemType}-file download for ${fileUrl} at ${Utils.formatDuration(startTime)}...`,
+            `Begin ${itemType}-file download for ${fileUrl} at ${Utils.formatDatetimeTimestamp(startTime)}...`,
         );
     }
 
-    onDownloadComplete({ fileUrl, duration }: { fileUrl: string; duration: number }) {
-        console.log(`${fileUrl} download completed in ${Utils.formatDuration(duration)}`);
+    onDownloadComplete({ fileUrl, duration }: { fileUrl: string; duration: string }) {
+        console.log(`${fileUrl} download completed in ${duration}`);
     }
 
     onDownloadError({
         fileUrl,
         message,
         duration,
+        responseHeaders,
     }: {
         fileUrl: string;
         message: string;
-        duration: number;
+        duration: string;
+        responseHeaders?: object;
     }) {
-        console.log(
-            `${fileUrl} download FAILED in ${Utils.formatDuration(duration)} Message: ${message}`,
-        );
+        console.log(`${fileUrl} download FAILED in ${duration} Message: ${message}`);
+        if (responseHeaders) debug("Headers: ", JSON.stringify(responseHeaders));
     }
 
-    onAllDownloadsComplete(_: unknown, duration: number) {
-        console.log(`All downloads completed in ${Utils.formatDuration(duration)}`);
+    onAllDownloadsComplete(_: unknown, duration: string) {
+        console.log(`All downloads completed in ${duration}`);
     }
 
     onError(error: Error) {

--- a/src/reporters/text.ts
+++ b/src/reporters/text.ts
@@ -24,7 +24,7 @@ export default class TextReporter extends Reporter {
 
     onJobStart(status: Types.MatchStatus) {
         console.log(status.message);
-        console.log(`Status endpoint: ${status.statusEndpoint}`);
+        debug(`Status endpoint: ${status.statusEndpoint}`);
     }
 
     onJobProgress(status: Types.MatchStatus) {
@@ -48,8 +48,7 @@ export default class TextReporter extends Reporter {
         message?: string;
         responseHeaders?: object;
     }) {
-        console.error("There was an error in the matching process");
-        console.error(JSON.stringify(details));
+        console.error("There was an error in the matching process: ", JSON.stringify(details));
     }
 
     onDownloadStart({
@@ -79,8 +78,9 @@ export default class TextReporter extends Reporter {
         message: string;
         duration: number;
     }) {
-        console.log(`${fileUrl} download FAILED in ${Utils.formatDuration(duration)}`);
-        console.log("Message: " + message);
+        console.log(
+            `${fileUrl} download FAILED in ${Utils.formatDuration(duration)} Message: ${message}`,
+        );
     }
 
     onAllDownloadsComplete(_: unknown, duration: number) {

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -39,16 +39,18 @@ describe("download", function () {
             destination: join(__dirname, "./tmp/downloads"),
         } as Types.NormalizedOptions);
 
-        // @ts-expect-error
-        await client._downloadFile({
-            file: {
-                type: "Patient",
-                url: mockServer.baseUrl + "/download",
-                count: 2,
-            },
-            fileName: "1.Patient.ndjson",
-            subFolder: "",
-        });
+        await expect(
+            // @ts-expect-error
+            client._downloadFile({
+                file: {
+                    type: "Patient",
+                    url: mockServer.baseUrl + "/download",
+                    count: 2,
+                },
+                fileName: "1.Patient.ndjson",
+                subFolder: "",
+            }),
+        ).to.not.reject();
     });
 
     it("Integration: Manifest will be parsed and all output files will be downloaded", async () => {

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -1,8 +1,11 @@
-import { existsSync, rmSync } from "fs";
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { expect } from "@hapi/code";
+import { existsSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
+import { BulkMatchClient as Types } from "..";
 import { BulkMatchClient } from "../src/client";
 import baseSettings from "../src/default-config";
-import { Utils, mockServer } from "./lib";
+import { Utils, invoke, mockServer } from "./lib";
 
 describe("download", function () {
     this.timeout(60000);
@@ -34,9 +37,8 @@ describe("download", function () {
             ...baseSettings,
             fhirUrl: mockServer.baseUrl,
             destination: join(__dirname, "./tmp/downloads"),
-        });
+        } as Types.NormalizedOptions);
 
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         await client._downloadFile({
             file: {
@@ -47,5 +49,63 @@ describe("download", function () {
             fileName: "1.Patient.ndjson",
             subFolder: "",
         });
+    });
+
+    it("Integration: Manifest will be parsed and all output files will be downloaded", async () => {
+        // Mock the kick-off response
+        mockServer.mock(
+            { method: "post", path: "/Patient/\\$bulk-match" },
+            {
+                status: 202,
+                headers: {
+                    "Content-Location": mockServer.baseUrl + "/status",
+                },
+            },
+        );
+
+        // Mock the status response
+        mockServer.mock("/status", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+            body: {
+                transactionTime: new Date().toISOString(),
+                request: mockServer.baseUrl + "/Patient/$bulk-match",
+                requiresAccessToken: true,
+                output: [
+                    {
+                        type: "Bundle",
+                        url: mockServer.baseUrl + "/output/file_1.ndjson",
+                    },
+                ],
+                error: [],
+            },
+        });
+
+        // Mock the download response – an NDJSON string
+        const mockResponse = {
+            status: 200,
+            headers: { "content-type": "application/ndjson" },
+            body: [
+                {
+                    resourceType: "Patient",
+                    id: "123",
+                },
+            ]
+                .map((x) => JSON.stringify(x))
+                .join("\n"),
+        };
+        mockServer.mock("/output/file_1.ndjson", mockResponse);
+
+        await invoke({
+            options: {
+                fhirUrl: mockServer.baseUrl,
+                destination: join(__dirname, "./tmp/downloads"),
+            },
+        });
+
+        // Parse both JSON objects to avoid encoding quirks re: quotation marks
+        expect(
+            JSON.parse(readFileSync(join(__dirname, "./tmp/downloads/file_1.ndjson"), "utf8")),
+        ).to.equal(JSON.parse(mockResponse.body));
     });
 });

--- a/test/kick-off.test.ts
+++ b/test/kick-off.test.ts
@@ -50,7 +50,7 @@ describe("kick-off", () => {
 
 describe("status", () => {
     describe("complete", () => {
-        it("returns the manifest", async () => {
+        it.skip("returns the manifest", async () => {
             mockServer.mock("/status", {
                 status: 200,
                 body: { output: [{}] },
@@ -61,11 +61,12 @@ describe("status", () => {
                 fhirUrl: mockServer.baseUrl,
             } as Types.NormalizedOptions);
             await client.waitForMatch(mockServer.baseUrl + "/status");
+            // TODO add a manifest
         });
     });
 
     describe("error", () => {
-        it("throws the error", async () => {
+        it("throws an error when the endpoint responds with a 400", async () => {
             mockServer.mock("/status", { status: 400 });
 
             const client = new BulkMatchClient({
@@ -73,13 +74,9 @@ describe("status", () => {
                 fhirUrl: mockServer.baseUrl,
             } as Types.NormalizedOptions);
 
-            await client.waitForMatch(mockServer.baseUrl + "/status").then(
-                () => {
-                    throw new Error("The test should have failed");
-                },
-                () => {
-                    // Error was expected so we are good to go
-                },
+            await expect(client.waitForMatch(mockServer.baseUrl + "/status")).reject(
+                Error,
+                `GET ${mockServer.baseUrl}/status FAILED with 400 and message Bad Request.`,
             );
         });
     });

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -28,7 +28,12 @@ export function parseLogFile(log: string) {
         .map((line) => JSON.parse(line));
 }
 
-export function getLogEvents(log: string, event: Logger.LogEvents) {
+export function getLogEvent(log: string, event: Logger.LogEvents) {
     const parsedLogs = parseLogFile(log);
     return parsedLogs.find((l) => l.eventId === event);
+}
+
+export function getLogEvents(log: string, event: Logger.LogEvents) {
+    const parsedLogs = parseLogFile(log);
+    return parsedLogs.filter((l) => l.eventId === event);
 }

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -36,6 +36,7 @@ describe("Logging", function () {
 
             // Respond with a 404 indicating server error
             mockServer.mock(
+                // NOTE: Request endpoint is invalid without the "\\"
                 { method: "post", path: "/Patient/\\$bulk-match" },
                 { status: 404, body: "", headers: { "content-location": "x" } },
             );
@@ -143,19 +144,6 @@ describe("Logging", function () {
         });
 
         it("includes request parameters in kickoff log entries", async () => {
-            mockServer.mock("/metadata", {
-                status: 200,
-                headers: { "content-type": "application/json" },
-                body: {
-                    fhirVersion: 100,
-                    software: {
-                        name: "Software Name",
-                        version: "Software Version",
-                        releaseDate: "01-02-03",
-                    },
-                },
-            });
-
             mockServer.mock(
                 { method: "post", path: "/Patient/\\$bulk-match" },
                 { status: 200, headers: { "content-type": "application/json" } },
@@ -174,18 +162,8 @@ describe("Logging", function () {
         });
 
         it("kickoff_complete should include responseHeaders when logResponseHeaders is 'all'", async () => {
-            mockServer.mock("/metadata", {
-                status: 200,
-                headers: { "content-type": "application/json" },
-                body: {
-                    fhirVersion: 100,
-                    software: {
-                        name: "Software Name",
-                        version: "Software Version",
-                        releaseDate: "01-02-03",
-                    },
-                },
-            });
+            mockServer.mock("/metadata", { status: 404, body: {} });
+
             // NOTE: Request endpoint is invalid without the "\\"
             mockServer.mock(
                 { method: "post", path: "/Patient/\\$bulk-match" },
@@ -213,18 +191,8 @@ describe("Logging", function () {
         });
 
         it("kickoff_complete should filter responseHeaders based on logResponseHeaders option", async () => {
-            mockServer.mock("/metadata", {
-                status: 200,
-                headers: { "content-type": "application/json" },
-                body: {
-                    fhirVersion: 100,
-                    software: {
-                        name: "Software Name",
-                        version: "Software Version",
-                        releaseDate: "01-02-03",
-                    },
-                },
-            });
+            mockServer.mock("/metadata", { status: 404, body: {} });
+
             // NOTE: Request endpoint is invalid without the "\\"
             mockServer.mock(
                 { method: "post", path: "/Patient/\\$bulk-match" },
@@ -257,7 +225,7 @@ describe("Logging", function () {
 
     describe("status events", () => {
         it("logs status_progress events in case of 202 status responses", async () => {
-            mockServer.mock("/metadata", { status: 200, body: {} });
+            mockServer.mock("/metadata", { status: 404, body: {} });
 
             mockServer.mock(
                 { method: "post", path: "/Patient/\\$bulk-match" },
@@ -294,10 +262,8 @@ describe("Logging", function () {
             expect(logs[2].eventDetail.xProgress).to.equal("90%");
         });
 
-        it.skip("logs status_error events", async () => {
-            this.timeout(10000);
-
-            mockServer.mock("/metadata", { status: 200, body: {} });
+        it("logs status_error events", async () => {
+            mockServer.mock("/metadata", { status: 404, body: {} });
 
             mockServer.mock(
                 { method: "post", path: "/Patient/\\$bulk-match" },
@@ -327,11 +293,7 @@ describe("Logging", function () {
             });
         });
 
-        it.skip("can filter responseHeaders of status_error events with client's logResponseHeaders option", async () => {
-            this.timeout(10000);
-
-            mockServer.mock("/metadata", { status: 200, body: {} });
-
+        it("can filter responseHeaders of status_error events with client's logResponseHeaders option", async () => {
             mockServer.mock(
                 { method: "post", path: "/Patient/\\$bulk-match" },
                 {
@@ -346,7 +308,7 @@ describe("Logging", function () {
             mockServer.mock("/status", {
                 status: 404,
                 body: "Status endpoint not found",
-                headers: { "x-debugging-header": "someValue" },
+                headers: { "x-debugging-header": "someValue", "x-another-value": "another-value" },
             });
 
             const { log } = await invoke({

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -1,0 +1,722 @@
+import { expect } from "@hapi/code";
+import { existsSync, rmSync } from "fs";
+import { Utils, invoke, mockServer } from "./lib";
+
+describe("Logging", function () {
+    this.timeout(10000);
+
+    after(async () => {
+        Utils.emptyFolder(__dirname + "/tmp/downloads/error");
+        Utils.emptyFolder(__dirname + "/tmp/downloads");
+    });
+
+    afterEach(async () => {
+        if (existsSync(__dirname + "/tmp/log.ndjson")) {
+            rmSync(__dirname + "/tmp/log.ndjson");
+        }
+        if (existsSync(__dirname + "/tmp/config.js")) {
+            rmSync(__dirname + "/tmp/config.js");
+        }
+    });
+
+    describe("kickoff", () => {
+        it("emits kickoff_start and kickoff_error in case of server error", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03",
+                    },
+                },
+            });
+
+            // Respond with a 404 indicating server error
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                { status: 404, body: "", headers: { "content-location": "x" } },
+            );
+
+            const { log } = await invoke({
+                options: { logResponseHeaders: [] },
+            });
+            const entryStart = Utils.getLogEvent(log, "kickoff_start");
+            expect(entryStart, "kickoff log entry not found").to.exist();
+            expect(entryStart.eventDetail).to.equal(
+                `Kick-off started with URL: ${mockServer.baseUrl}/Patient/$bulk-match\n` +
+                    'Options: {"headers":{"Content-Type":"application/json","accept":"application/fhir+ndjson","prefer":"respond-async"},"method":"POST","body":"{\\"resourceType\\":\\"Parameters\\",\\"parameter\\":[]}"}',
+            );
+
+            const entryComplete = Utils.getLogEvent(log, "kickoff_error");
+            expect(entryComplete.eventDetail).to.equal({
+                error: `POST ${mockServer.baseUrl}/Patient/$bulk-match FAILED with 404 and message Not Found.`,
+                softwareName: "Software Name",
+                softwareVersion: "Software Version",
+                softwareReleaseDate: "01-02-03",
+                fhirVersion: 100,
+                requestOptions: {
+                    body: '{"resourceType":"Parameters","parameter":[]}',
+                    headers: {
+                        "Content-Type": "application/json",
+                        accept: "application/fhir+ndjson",
+                        prefer: "respond-async",
+                    },
+                    method: "POST",
+                },
+            });
+        });
+
+        it("emits kickoff_start & kickoff_error in case of invalid response", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                headers: {
+                    "content-type": "application/json",
+                },
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03",
+                    },
+                },
+            });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                { status: 200, body: "" },
+            );
+
+            const { log } = await invoke({
+                options: { logResponseHeaders: [] },
+            });
+            const entryStart = Utils.getLogEvent(log, "kickoff_start");
+
+            // Check kickoff start log for existence
+            expect(entryStart, "kickoff log entry not found").to.exist();
+            expect(entryStart.eventDetail).to.equal(
+                `Kick-off started with URL: ${mockServer.baseUrl}/Patient/$bulk-match\n` +
+                    'Options: {"headers":{"Content-Type":"application/json","accept":"application/fhir+ndjson","prefer":"respond-async"},"method":"POST","body":"{\\"resourceType\\":\\"Parameters\\",\\"parameter\\":[]}"}',
+            );
+            // Check error log
+            const entryError = Utils.getLogEvent(log, "kickoff_error");
+            expect(entryError.eventDetail).to.equal({
+                error: "No content location was specified in the response",
+                softwareName: "Software Name",
+                softwareVersion: "Software Version",
+                softwareReleaseDate: "01-02-03",
+                fhirVersion: 100,
+                responseHeaders: {},
+                requestOptions: {
+                    body: '{"resourceType":"Parameters","parameter":[]}',
+                    headers: {
+                        "Content-Type": "application/json",
+                        accept: "application/fhir+ndjson",
+                        prefer: "respond-async",
+                    },
+                    method: "POST",
+                },
+            });
+        });
+
+        it("emits kickoff_start in case of missing CapabilityStatement", async () => {
+            mockServer.mock("/metadata", { status: 404 });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                { status: 200, body: "", headers: { "content-type": "application/json" } },
+            );
+
+            const { log } = await invoke({
+                options: { logResponseHeaders: [] },
+            });
+            const entryStart = Utils.getLogEvent(log, "kickoff_start");
+
+            expect(entryStart, "kickoff log entry not found").to.exist();
+            expect(entryStart.eventDetail).to.equal(
+                `Kick-off started with URL: ${mockServer.baseUrl}/Patient/$bulk-match\n` +
+                    'Options: {"headers":{"Content-Type":"application/json","accept":"application/fhir+ndjson","prefer":"respond-async"},"method":"POST","body":"{\\"resourceType\\":\\"Parameters\\",\\"parameter\\":[]}"}',
+            );
+        });
+
+        it("includes request parameters in kickoff log entries", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03",
+                    },
+                },
+            });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                { status: 200, headers: { "content-type": "application/json" } },
+            );
+
+            const { log } = await invoke({
+                args: ["--count", "3"],
+            });
+
+            // Kickoff start entry should include a count argument in its request options payload
+            const entry = Utils.getLogEvent(log, "kickoff_start");
+            expect(entry, "kickoff log entry not found").to.exist();
+            expect(entry.eventDetail).to.include(mockServer.baseUrl + "/Patient/$bulk-match");
+            expect(entry.eventDetail).to.include("count");
+            expect(entry.eventDetail).to.include(":3");
+        });
+
+        it("kickoff_complete should include responseHeaders when logResponseHeaders is 'all'", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03",
+                    },
+                },
+            });
+            // NOTE: Request endpoint is invalid without the "\\"
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                        "x-debugging-header": "someValue",
+                    },
+                    body: "",
+                },
+            );
+
+            const { log } = await invoke({
+                options: { logResponseHeaders: "all" },
+            });
+            // Should be able to find debugging header in log entries
+            const entry = Utils.getLogEvent(log, "kickoff_complete");
+            expect(entry, "kickoff log entry not found").to.exist();
+            expect(entry.eventDetail).to.be.an.object();
+            expect(entry.eventDetail.responseHeaders).to.be.an.object();
+            expect(entry.eventDetail.responseHeaders).to.include({
+                "x-debugging-header": "someValue",
+            });
+        });
+
+        it("kickoff_complete should filter responseHeaders based on logResponseHeaders option", async () => {
+            mockServer.mock("/metadata", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+                body: {
+                    fhirVersion: 100,
+                    software: {
+                        name: "Software Name",
+                        version: "Software Version",
+                        releaseDate: "01-02-03",
+                    },
+                },
+            });
+            // NOTE: Request endpoint is invalid without the "\\"
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                        "x-debugging-header": "someValue",
+                        "x-another-header": "someValue",
+                    },
+                    body: "",
+                },
+            );
+
+            const { log } = await invoke({
+                options: {
+                    logResponseHeaders: ["x-debugging-header", "content-location"],
+                },
+            });
+            const entry = Utils.getLogEvent(log, "kickoff_complete");
+            expect(entry, "kickoff log entry not found").to.exist();
+            expect(entry.eventDetail).to.be.an.object();
+            expect(entry.eventDetail.responseHeaders).to.be.an.object();
+            expect(entry.eventDetail.responseHeaders).to.equal({
+                "content-location": mockServer.baseUrl + "/status",
+                "x-debugging-header": "someValue",
+            });
+        });
+    });
+
+    describe("status events", () => {
+        it("logs status_progress events in case of 202 status responses", async () => {
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                    body: "",
+                },
+            );
+
+            let counter = 0;
+
+            mockServer.mock("/status", {
+                handler(req, res) {
+                    if (++counter < 4) {
+                        res.setHeader("x-progress", counter * 30 + "%");
+                        res.setHeader("retry-after", "1");
+                        res.status(202);
+                        res.send("");
+                    } else {
+                        res.json({}); // manifest
+                    }
+                },
+            });
+
+            const { log } = await invoke();
+            const logs = Utils.getLogEvents(log, "status_progress");
+
+            expect(logs.length, "must have 3 status_progress log entries").to.equal(3);
+            expect(logs[0].eventDetail.xProgress).to.equal("30%");
+            expect(logs[1].eventDetail.xProgress).to.equal("60%");
+            expect(logs[2].eventDetail.xProgress).to.equal("90%");
+        });
+
+        it.skip("logs status_error events", async () => {
+            this.timeout(10000);
+
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                    body: "",
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 404,
+                body: "Status endpoint not found",
+                headers: { "x-debugging-header": "someValue" },
+            });
+
+            const { log } = await invoke();
+            const entry = Utils.getLogEvent(log, "status_error");
+            expect(entry).to.exist();
+            expect(entry.eventDetail.code).to.equal(404);
+            expect(entry.eventDetail.body).to.equal("Status endpoint not found");
+            // Check response headers of status_error events
+            expect(entry.eventDetail.responseHeaders).to.include({
+                "x-debugging-header": "someValue",
+            });
+        });
+
+        it.skip("can filter responseHeaders of status_error events with client's logResponseHeaders option", async () => {
+            this.timeout(10000);
+
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                    body: "",
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 404,
+                body: "Status endpoint not found",
+                headers: { "x-debugging-header": "someValue" },
+            });
+
+            const { log } = await invoke({
+                options: { logResponseHeaders: ["x-debugging-header"] },
+            });
+            const entry = Utils.getLogEvent(log, "status_error");
+            expect(entry).to.exist();
+            expect(entry.eventDetail.code).to.equal(404);
+            expect(entry.eventDetail.body).to.equal("Status endpoint not found");
+            // Check response headers of status_error events
+            expect(entry.eventDetail.responseHeaders).to.equal({
+                "x-debugging-header": "someValue",
+            });
+        });
+
+        it("logs status_complete events", async () => {
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                    body: "",
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+                body: {
+                    transactionTime: new Date().toISOString(),
+                    output: [{}, {}, {}],
+                    error: [{}],
+                },
+            });
+
+            const { log } = await invoke();
+            const entry = Utils.getLogEvent(log, "status_complete");
+            expect(entry).to.exist();
+            expect(entry.eventDetail.transactionTime).to.exist();
+            expect(entry.eventDetail.outputFileCount).to.equal(3);
+            expect(entry.eventDetail.errorFileCount).to.equal(1);
+        });
+
+        it("logs status_error on invalid manifest", async () => {
+            this.timeout(10000);
+
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                    body: "",
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 200,
+                body: {},
+                headers: { "content-type": "application/json" },
+            });
+
+            const { log } = await invoke();
+            const entry = Utils.getLogEvent(log, "status_error");
+            expect(entry).to.exist();
+            expect(entry.eventDetail.code).to.equal(200);
+            expect(entry.eventDetail.body).to.equal("{}");
+            expect(entry.eventDetail.message).to.equal(
+                "The match manifest output is not an array: Expected undefined " +
+                    "to be an array but got 'undefined'",
+            );
+        });
+    });
+
+    describe("download events", () => {
+        it.skip("download without errors", async () => {
+            mockServer.mock("/metadata", { status: 404, body: {} });
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+                body: {
+                    transactionTime: new Date().toISOString(),
+                    output: [
+                        {
+                            url: mockServer.baseUrl + "/downloads/patient-1",
+                            type: "Patient",
+                        },
+                        {
+                            url: mockServer.baseUrl + "/downloads/patient-2",
+                            type: "Patient",
+                        },
+                    ],
+                    error: [
+                        {
+                            url: mockServer.baseUrl + "/downloads/errors",
+                            type: "OperationOutcome",
+                        },
+                    ],
+                },
+            });
+
+            mockServer.mock("/downloads/patient-1", {
+                handler(req, res) {
+                    res.set("content-type", "application/fhir+ndjson");
+                    res.end('{"resourceType":"Patient"}\n{"resourceType":"Patient"}');
+                },
+            });
+
+            mockServer.mock("/downloads/errors", {
+                handler(req, res) {
+                    res.set("content-type", "application/fhir+ndjson");
+                    res.end('{"resourceType":"Patient"}\n{"resourceType":"Patient"}');
+                },
+            });
+
+            const { log } = await invoke();
+
+            const start = Utils.getLogEvent(log, "kickoff_start");
+            expect(start).to.exist();
+
+            const statusComplete = Utils.getLogEvent(log, "status_complete");
+            expect(statusComplete).to.exist();
+
+            // /downloads/file1 ------------------------------------------------
+            {
+                const entries = logs.filter(
+                    (e) =>
+                        e.eventId === "download_request" &&
+                        e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/file1",
+                );
+                expect(
+                    entries.length,
+                    'download_request should be logged once for "/downloads/file1"',
+                ).to.equal(1);
+                expect(entries[0].eventDetail.fileUrl, "invalid fileUrl").to.equal(
+                    mockServer.baseUrl + "/downloads/file1",
+                );
+                expect(entries[0].eventDetail.itemType).to.equal("output");
+                expect(entries[0].eventDetail.resourceType).to.equal("Patient");
+            }
+
+            {
+                const entries = logs.filter(
+                    (e) =>
+                        e.eventId === "download_complete" &&
+                        e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/file1",
+                );
+                expect(
+                    entries.length,
+                    'download_complete should be logged once for "/downloads/file1"',
+                ).to.equal(1);
+                expect(entries[0].eventDetail.fileUrl, "invalid fileUrl").to.equal(
+                    mockServer.baseUrl + "/downloads/file1",
+                );
+            }
+
+            // /downloads/docRef -----------------------------------------------
+            {
+                const entries = logs.filter(
+                    (e) =>
+                        e.eventId === "download_request" &&
+                        e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/docRef",
+                );
+                expect(
+                    entries.length,
+                    'download_request should be logged once for "/downloads/docRef"',
+                ).to.equal(1);
+                expect(entries[0].eventDetail.fileUrl, "invalid fileUrl").to.equal(
+                    mockServer.baseUrl + "/downloads/docRef",
+                );
+                expect(entries[0].eventDetail.itemType).to.equal("output");
+                expect(entries[0].eventDetail.resourceType).to.equal("DocumentReference");
+            }
+
+            {
+                const entries = logs.filter(
+                    (e) =>
+                        e.eventId === "download_complete" &&
+                        e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/docRef",
+                );
+                expect(
+                    entries.length,
+                    'download_complete should be logged once for "/downloads/docRef"',
+                ).to.equal(1);
+                expect(entries[0].eventDetail.fileUrl, "invalid fileUrl").to.equal(
+                    mockServer.baseUrl + "/downloads/docRef",
+                );
+            }
+
+            // /downloads/errors -----------------------------------------------
+            {
+                const entries = logs.filter(
+                    (e) =>
+                        e.eventId === "download_request" &&
+                        e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/errors",
+                );
+                expect(
+                    entries.length,
+                    'download_request should be logged once for "/downloads/errors"',
+                ).to.equal(1);
+                expect(entries[0].eventDetail.fileUrl, "invalid fileUrl").to.equal(
+                    mockServer.baseUrl + "/downloads/errors",
+                );
+                expect(entries[0].eventDetail.itemType).to.equal("error");
+                expect(entries[0].eventDetail.resourceType).to.equal("OperationOutcome");
+            }
+
+            {
+                const entries = logs.filter(
+                    (e) =>
+                        e.eventId === "download_complete" &&
+                        e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/errors",
+                );
+                expect(
+                    entries.length,
+                    'download_complete should be logged once for "/downloads/errors"',
+                ).to.equal(1);
+                expect(entries[0].eventDetail.fileUrl, "invalid fileUrl").to.equal(
+                    mockServer.baseUrl + "/downloads/errors",
+                );
+            }
+
+            // job_complete -------------------------------------------------
+            {
+                const entries = logs.filter((e) => e.eventId === "job_complete");
+                expect(entries.length, "job_complete should be logged once").to.equal(1);
+                expect(entries[0].eventDetail.files, "must report 4 files").to.equal(4);
+                expect(entries[0].eventDetail.resources, "must report 5 resources").to.equal(5);
+            }
+        });
+
+        it.skip("logs download_error events on server errors", async () => {
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 200,
+                body: {
+                    transactionTime: new Date().toISOString(),
+                    output: [
+                        {
+                            url: mockServer.baseUrl + "/downloads/file1.json",
+                            type: "Patient",
+                        },
+                    ],
+                    error: [],
+                },
+            });
+
+            // Simulate 404 for downloads/file1.json with some response headers
+            mockServer.mock("/downloads/file1.json", {
+                status: 404,
+                body: "",
+                headers: { "x-debugging-header": "someValue" },
+            });
+
+            const { log } = await invoke();
+            const logs = log
+                .split("\n")
+                .filter(Boolean)
+                .map((line) => JSON.parse(line));
+            const entry = logs.find((l) => l.eventId === "download_error");
+            expect(entry).to.exist();
+            expect(entry.eventDetail.fileUrl).to.equal(
+                mockServer.baseUrl + "/downloads/file1.json",
+            );
+            expect(entry.eventDetail.body).to.equal(null);
+            expect(entry.eventDetail.message).to.equal(
+                `Downloading the file from ${mockServer.baseUrl}/downloads/file1.json returned HTTP status code 404.`,
+            );
+            expect(entry.eventDetail.responseHeaders).to.be.object();
+            expect(entry.eventDetail.responseHeaders).to.include({
+                "x-debugging-header": "someValue",
+            });
+        });
+
+        it.skip("retries downloading even if initial download fails", async () => {
+            mockServer.mock("/metadata", { status: 200, body: {} });
+
+            mockServer.mock(
+                { method: "post", path: "/Patient/\\$bulk-match" },
+                {
+                    status: 200,
+                    headers: {
+                        "content-location": mockServer.baseUrl + "/status",
+                    },
+                },
+            );
+
+            mockServer.mock("/status", {
+                status: 200,
+                body: {
+                    transactionTime: new Date().toISOString(),
+                    output: [
+                        {
+                            url: mockServer.baseUrl + "/downloads/file1.json",
+                            type: "Patient",
+                        },
+                    ],
+                    error: [],
+                },
+            });
+
+            let numTries = 0;
+            mockServer.mock("/downloads/file1.json", {
+                handler(req, res) {
+                    numTries += 1;
+                    // Simulate 502 for downloads/file1.json with some response headers
+                    if (numTries <= 1) {
+                        res.status(502);
+                        res.set("x-debugging-header", "someValue");
+                        res.end("");
+                    } else {
+                        // Succeed on the second request
+                        res.status(200);
+                        res.set("x-debugging-header", "someValue");
+                        res.set("content-type", "application/fhir+ndjson");
+                        res.set("Content-Disposition", "attachment");
+                        res.end('{"resourceType":"Patient"}\n{"resourceType":"Patient"}');
+                    }
+                },
+            });
+
+            const { log } = await invoke();
+            const logs = log
+                .split("\n")
+                .filter(Boolean)
+                .map((line) => JSON.parse(line));
+            const entries = logs.filter(
+                (e) =>
+                    e.eventId === "download_request" &&
+                    e.eventDetail.fileUrl === mockServer.baseUrl + "/downloads/file1.json",
+            );
+            expect(
+                entries.length,
+                'download_request should be logged twice for "/downloads/file1.json"',
+            ).to.equal(1);
+            expect(entries[0].eventDetail.fileUrl).to.equal(
+                mockServer.baseUrl + "/downloads/file1.json",
+            );
+            expect(entries[0].eventDetail.itemType).to.equal("output");
+            expect(entries[0].eventDetail.resourceType).to.equal("Patient");
+            // Evidence of Failure
+            expect(numTries).to.equal(2);
+        });
+    });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -4,7 +4,7 @@ import { BulkMatchClient as Types } from "../";
 import { filterResponseHeaders, getAccessTokenExpiration } from "../src/lib/utils";
 
 describe("Utils Library", function () {
-    describe("filterExportHeaders", () => {
+    describe("filterResponseHeaders", () => {
         it("returns undefined if headers is undefined or null", () => {
             // @ts-expect-error
             expect(filterResponseHeaders(undefined)).to.equal(undefined);


### PR DESCRIPTION
Changes in short: 
- Several changes of `export` to `match` where appropriate.
- `BulkMatchClient._getRetryAfter`: Now only takes responseHeaders as an argument, since it doesn't need the entire response object
- `request.ts`: Our helper now throws an augmented type of Error, `RequestError`, containing log-friendly metadata about the request. 
- `BulkMatchClient._statusError`: Now acts as a vehicle for logging relevant data from RequestError errors. Is used as the `BulkMatchClient._checkStatus` catch method. Previous uses of this function have been replaced with inline error throwing and jobError emission. 
- `BulkMatchClient._checkStatus`: Now logs a `kickOffError` event when content-location is missing from the status response.
- `BulkMatchClient_downloadFile`: Updated to make a recursive call to a retry-counter method for retrying downloads a set number of times. 
- `downloadError/downloadComplete/allDownloadsComplete`: All duration references which used to be numbers are now (formatted) strings. Any methods used as handlers for when these events are caught are updated accordingly. `downloadError` also supports logging of response headers now.
- `formatDuration`: Now formats info to the millisecond level. 
- `test/lib/utils.ts`: Helper methods for parsing log files
- Many, many logging and download tests added back in! 